### PR TITLE
fix: inline lightweight HTTP handler for server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,34 +1,123 @@
-﻿import express from 'express';
-import serverless from '@yandex-cloud/function-express';
 import { verifyInitData } from './tg-validate.js';
 import { DemoStore } from './storage.js';
 
-const app = express();
-app.use(express.json());
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, X-Telegram-Init-Data',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+};
 
-app.use((req,res,next)=>{
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Telegram-Init-Data');
-  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
-  if (req.method === 'OPTIONS') return res.end();
-  next();
-});
+const JSON_HEADERS = {
+  ...CORS_HEADERS,
+  'Content-Type': 'application/json',
+};
 
-app.get('/health', (req,res)=> res.json({ok:true}));
+const NO_CONTENT_RESPONSE = {
+  statusCode: 204,
+  headers: { ...CORS_HEADERS },
+  body: '',
+  isBase64Encoded: false,
+};
 
-app.post('/api/applications', (req,res)=>{
-  const initData = req.header('X-Telegram-Init-Data') || '';
-  const { BOT_TOKEN='dummy', DEMO='1' } = process.env;
-  if (DEMO !== '1' && !verifyInitData(initData, BOT_TOKEN)) {
-    return res.status(401).json({error:'unauthorized'});
+function jsonResponse(statusCode, payload, extraHeaders = {}) {
+  return {
+    statusCode,
+    headers: {
+      ...JSON_HEADERS,
+      ...extraHeaders,
+    },
+    body: JSON.stringify(payload),
+    isBase64Encoded: false,
+  };
+}
+
+function errorResponse(statusCode, error) {
+  return jsonResponse(statusCode, { error });
+}
+
+function normalizePath(path) {
+  if (!path) return '/';
+  const qIndex = path.indexOf('?');
+  const cleanPath = qIndex >= 0 ? path.slice(0, qIndex) : path;
+  if (cleanPath.length > 1 && cleanPath.endsWith('/')) {
+    return cleanPath.slice(0, -1);
   }
-  const { name, username } = req.body || {};
-  if (!name || !username) return res.status(400).json({error:'bad_payload'});
+  return cleanPath || '/';
+}
 
-  DemoStore.add({ name, username, ts: Date.now() });
-  return res.json({ok:true});
-});
+function collectHeaders(event) {
+  const source = event?.headers || {};
+  const result = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value === 'string') {
+      result[key.toLowerCase()] = value;
+    } else if (Array.isArray(value)) {
+      result[key.toLowerCase()] = value.join(',');
+    }
+  }
+  return result;
+}
 
-app.get('/api/applications', (req,res)=> res.json(DemoStore.list()));
+function parseBody(event) {
+  if (!event || typeof event.body !== 'string') {
+    return {};
+  }
+  let raw = event.body;
+  if (event.isBase64Encoded) {
+    raw = Buffer.from(raw, 'base64').toString();
+  }
+  if (!raw.trim()) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
 
-export const handler = serverless(app);
+export async function handler(event = {}) {
+  const method = (event.httpMethod || event.requestContext?.http?.method || 'GET').toUpperCase();
+
+  if (method === 'OPTIONS') {
+    return NO_CONTENT_RESPONSE;
+  }
+
+  const path = normalizePath(event.rawPath || event.path || event.requestContext?.http?.path || '/');
+  const headers = collectHeaders(event);
+
+  if (method === 'GET' && path === '/health') {
+    return jsonResponse(200, { ok: true });
+  }
+
+  if (path === '/api/applications') {
+    if (method === 'GET') {
+      return jsonResponse(200, DemoStore.list());
+    }
+
+    if (method === 'POST') {
+      const initData = headers['x-telegram-init-data'] || '';
+      const { BOT_TOKEN = 'dummy', DEMO = '1' } = process.env;
+      if (DEMO !== '1' && !verifyInitData(initData, BOT_TOKEN)) {
+        return errorResponse(401, 'unauthorized');
+      }
+
+      const payload = parseBody(event);
+      if (!payload) {
+        return errorResponse(400, 'bad_payload');
+      }
+
+      const { name, username } = payload;
+      if (!name || !username) {
+        return errorResponse(400, 'bad_payload');
+      }
+
+      DemoStore.add({ name, username, ts: Date.now() });
+      return jsonResponse(200, { ok: true });
+    }
+  }
+
+  return errorResponse(404, 'not_found');
+}
+
+export default handler;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "form-networking-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": false,
+  "packages": {
+    "": {
+      "name": "form-networking-server",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,9 +1,6 @@
-﻿{
+{
   "name": "form-networking-server",
+  "version": "1.0.0",
   "type": "module",
-  "main": "index.js",
-  "dependencies": {
-    "@yandex-cloud/function-express": "^1.0.1",
-    "express": "^4.19.2"
-  }
+  "main": "index.js"
 }


### PR DESCRIPTION
## Summary
- reimplement the serverless handler without Express/@yandex-cloud/function-express to remove the dependency on npm packages
- add a minimal package-lock.json so that `npm ci` succeeds during the deployment workflow

## Testing
- npm ci (server)


------
https://chatgpt.com/codex/tasks/task_e_68d14ee73c94832f94a1ccb4a9e9c681