### PR TITLE
Fix API gateway deployment without SA flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,15 @@ jobs:
             --environment BOT_TOKEN=${BOT_TOKEN},DEMO=1 \
             --source-path server.zip
 
+      - name: Make function invokable (public for demo)
+        run: |
+          FN_ID=${{ steps.fn.outputs.id }}
+          # дать публичный инвокер, чтобы API GW мог вызывать без SA
+          yc serverless function add-access-binding \
+            --id "$FN_ID" \
+            --role serverless.functions.invoker \
+            --subject allUsers || true
+
       # ---------- API Gateway ----------
       - name: Prepare OpenAPI with function id
         run: |
@@ -142,20 +151,16 @@ jobs:
         id: gw
         run: |
           set -e
-          retry(){ local n=0; until "$@"; do n=$((n+1)); [ $n -ge 5 ] && return 1; sleep $((n*5)); done; }
-          SA_ID="${{ steps.sa.outputs.id }}"
-          if [ -z "$SA_ID" ]; then
-            echo "Service account id is empty" >&2
-            exit 1
-          fi
+          retry() { local n=0; until "$@"; do n=$((n+1)); [ $n -ge 5 ] && return 1; sleep $((n*5)); done; }
+
           if retry yc serverless api-gateway get --name "$APIGW_NAME" >/dev/null 2>&1; then
-            retry yc serverless api-gateway update --name "$APIGW_NAME" --spec=apigw.yaml --service-account-id "$SA_ID"
+            retry yc serverless api-gateway update --name "$APIGW_NAME" --spec=apigw.yaml
           else
-            retry yc serverless api-gateway create --name "$APIGW_NAME" --spec=apigw.yaml --service-account-id "$SA_ID"
+            retry yc serverless api-gateway create --name "$APIGW_NAME" --spec=apigw.yaml
           fi
-          GW_JSON=$(retry yc serverless api-gateway get --name "$APIGW_NAME" --format json)
-          GW_URL=$(echo "$GW_JSON" | jq -r .domain)
-          echo "url=https://${GW_URL}" >> $GITHUB_OUTPUT
+
+          GW_URL=$(retry yc serverless api-gateway get --name "$APIGW_NAME" --format json | jq -r '.domain')
+          echo "url=https://$GW_URL" >> $GITHUB_OUTPUT
 
       # ---------- Frontend: inject API URL & upload ----------
       - name: Inject API base URL into web/app.js


### PR DESCRIPTION
## Summary
- remove the unsupported `--service-account-id` flag from API Gateway create/update steps
- add a workflow step that grants the function a public invoker role for demo usage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d16990e688832fb9e6694c5c300ad5