### PR TITLE
Add service account to API Gateway deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,15 +100,21 @@ jobs:
         id: deploy-apigw
         env:
           FUNCTION_ID: ${{ steps.deploy-function.outputs.function_id }}
+          FUNCTION_INVOKER_SA_ID: ${{ steps.configure.outputs.service_account_id }}
         run: |
           set -euo pipefail
           if [ -z "${FUNCTION_ID:-}" ]; then
             echo "Function ID is required" >&2
             exit 1
           fi
+          if [ -z "${FUNCTION_INVOKER_SA_ID:-}" ]; then
+            echo "Function invoker service account ID is required" >&2
+            exit 1
+          fi
           API_GATEWAY_NAME_VALUE="${API_GATEWAY_NAME:-form-networking-gw}"
           SPEC_FILE="$RUNNER_TEMP/apigw.yaml"
           export FUNCTION_ID
+          export FUNCTION_INVOKER_SA_ID
           envsubst < infra/apigw-openapi.yaml > "$SPEC_FILE"
           if yc serverless api-gateway get --name "$API_GATEWAY_NAME_VALUE" >/dev/null 2>&1; then
             yc serverless api-gateway update --name "$API_GATEWAY_NAME_VALUE" --spec="$SPEC_FILE" >/dev/null

--- a/infra/apigw-openapi.yaml
+++ b/infra/apigw-openapi.yaml
@@ -16,6 +16,7 @@ paths:
       x-yc-apigateway-integration:
         type: cloud_functions
         function_id: ${FUNCTION_ID}
+        service_account_id: ${FUNCTION_INVOKER_SA_ID}
   /api/applications:
     get:
       responses:
@@ -37,6 +38,7 @@ paths:
       x-yc-apigateway-integration:
         type: cloud_functions
         function_id: ${FUNCTION_ID}
+        service_account_id: ${FUNCTION_INVOKER_SA_ID}
     post:
       responses:
         '200':
@@ -69,3 +71,4 @@ paths:
       x-yc-apigateway-integration:
         type: cloud_functions
         function_id: ${FUNCTION_ID}
+        service_account_id: ${FUNCTION_INVOKER_SA_ID}


### PR DESCRIPTION
## Summary
- include the function invoker service account in each API Gateway integration block
- pass the configured service account ID through the deployment workflow so it is exported during templating

## Testing
- not run (not applicable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2b516a660832f804515b9d239f8c8