### PR TITLE
Hook web form to API

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -4,11 +4,13 @@
   --accent:#ff7a1a; --accent-2:#ffae66; --ok:#22c55e; --err:#ef4444;
   --r:12px;
 }
-*{box-sizing:border-box} html,body{height:100%}
+*{box-sizing:border-box}
+html,body{height:100%}
 body{
   margin:0; background:var(--bg); color:var(--text);
   font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
 }
+[hidden]{display:none!important}
 
 /* Картинка будет позже; сейчас заглушка без отступа сверху */
 .hero{margin:0; padding:0}
@@ -22,6 +24,13 @@ body{
   margin:0 16px 32px; padding:20px; background:var(--surface);
   border:1px solid var(--line); border-radius:var(--r);
 }
+.card-success{
+  background:var(--surface-2);
+  border-color:var(--accent);
+}
+.card-success h2{margin:0 0 8px}
+.card-success p{margin:0}
+
 h1{margin:0 0 8px}
 .muted{color:var(--muted); margin:0 0 16px}
 label{display:block; margin:12px 0}
@@ -34,4 +43,10 @@ input::placeholder{color:#687385}
 button{
   margin-top:16px; border:0; cursor:pointer; padding:12px 18px;
   border-radius:12px; background:var(--accent); color:#111; font-weight:700;
+}
+button:disabled{
+  cursor:wait; opacity:0.7;
+}
+.error{
+  margin:8px 0 0; color:var(--err);
 }

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,7 @@
   <title>Регистрация участников</title>
   <link rel="stylesheet" href="./app.css">
 </head>
-<body>
+<body data-api-base="%%API_BASE%%">
   <header class="hero">
     <!-- Без картинок на первом шаге, чтобы ничего не «сломалось» -->
     <div class="hero-stub"></div>
@@ -16,27 +16,30 @@
 
   <main class="card" id="card-form">
     <h1>Заявка на нетворкинг</h1>
-    <p class="muted">Шаг 1: чистая статика с кнопкой. Бэкенд позже.</p>
+    <p class="muted">Укажите контакты, чтобы познакомиться с коллегами на событии.</p>
 
     <form id="form">
       <label>Имя
-        <input id="name" name="name" placeholder="Alex (Alexis)" required/>
+        <input id="name" name="name" placeholder="Alex (Alexis)" autocomplete="name" required/>
       </label>
 
       <label>Telegram @username
-        <input id="username" name="username" placeholder="@username" required/>
+        <input id="username" name="username" placeholder="@username" autocomplete="username" required/>
       </label>
 
-      <button id="submit" type="button">Отправить</button>
+      <p id="error" class="error" hidden></p>
+
+      <button id="submit" type="submit">Отправить</button>
     </form>
 
-    <p id="note" class="muted">Нажатие пока ничего не отправляет — это просто заглушка.</p>
+    <p id="note" class="muted">Телеграм-бот напомнит, если появятся новые анкеты для общения.</p>
   </main>
 
-  <script>
-    document.getElementById('submit').addEventListener('click', ()=>{
-      alert('Шаг 1: это статика. Бэкенд подключим на шаге 2.');
-    });
-  </script>
+  <section class="card card-success" id="card-success" hidden>
+    <h2>Заявка отправлена</h2>
+    <p>Мы получили ваши данные. Вернитесь в чат-бот, чтобы увидеть список участников.</p>
+  </section>
+
+  <script src="./app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the static button with a real form that posts to the API and shows a success card
- surface validation feedback and loading state styling for the submit button
- make the API base URL configurable through a data attribute with a graceful fallback

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3961e190c832faead458468c108d0