### PR TITLE
Add helper scripts for API Gateway deployment

### DIFF
--- a/apigw-openapi.resolved.yaml
+++ b/apigw-openapi.resolved.yaml
@@ -1,4 +1,5 @@
-﻿openapi: 3.0.0
+# Generated via infra/render-apigw.mjs from infra/apigw-openapi.yaml
+openapi: 3.0.0
 info: { title: form-networking, version: 1.0.0 }
 paths:
   /health:
@@ -15,7 +16,14 @@ paths:
                     type: boolean
       x-yc-apigateway-integration:
         type: cloud_functions
-        function_id: d4e68f622koeue2ltf8k
+        function_id: example-function-id
+    options:
+      responses:
+        '204':
+          description: CORS preflight
+      x-yc-apigateway-integration:
+        type: cloud_functions
+        function_id: example-function-id
   /api/applications:
     get:
       responses:
@@ -36,7 +44,7 @@ paths:
                       type: string
       x-yc-apigateway-integration:
         type: cloud_functions
-        function_id: d4e68f622koeue2ltf8k
+        function_id: example-function-id
     post:
       responses:
         '200':
@@ -68,4 +76,11 @@ paths:
                     type: string
       x-yc-apigateway-integration:
         type: cloud_functions
-        function_id: d4e68f622koeue2ltf8k
+        function_id: example-function-id
+    options:
+      responses:
+        '204':
+          description: CORS preflight
+      x-yc-apigateway-integration:
+        type: cloud_functions
+        function_id: example-function-id

--- a/infra/DEPLOYMENT.md
+++ b/infra/DEPLOYMENT.md
@@ -2,7 +2,9 @@
 
 This repository ships an automated GitHub Actions workflow that deploys the
 Telegram bot backend, API Gateway specification and static web assets to Yandex
-Cloud on every push to the `main` branch.
+Cloud on every push to the `main` branch. For manual experiments the
+`deploy-apigateway.sh` helper can be used to create or update the API Gateway
+locally once the Cloud Function has been published.
 
 ## Required secrets
 
@@ -31,6 +33,29 @@ Set the following repository variables to control the deployment targets:
 target folder and has the `serverless.functions.invoker` role on the function
 exposed through the API Gateway. When omitted, the workflow falls back to the
 service account ID embedded in `YC_SERVICE_ACCOUNT_KEY_B64`.
+
+## Manual gateway deployment
+
+To verify the API Gateway locally, publish the Cloud Function first and export
+its ID into the shell:
+
+```bash
+export FUNCTION_ID=... # yc serverless function get --name form-networking --format json | jq -r .id
+export YC_FOLDER_ID=...
+export YC_API_GATEWAY_NAME=form-networking-gw
+```
+
+When a dedicated invoker service account is required set
+`FUNCTION_INVOKER_SA_ID` (or `YC_FUNCTION_INVOKER_SA_ID`). Afterwards run:
+
+```bash
+./infra/deploy-apigateway.sh
+```
+
+The script renders `apigw-openapi.yaml` into `apigw-openapi.resolved.yaml` using
+the provided identifiers and calls `yc serverless api-gateway create` (or
+`update` when the gateway already exists). The final gateway description is
+printed in JSON format, including its public domain name.
 
 ## Workflow outputs
 

--- a/infra/apigw-openapi.yaml
+++ b/infra/apigw-openapi.yaml
@@ -17,6 +17,14 @@ paths:
         type: cloud_functions
         function_id: ${FUNCTION_ID}
         service_account_id: ${FUNCTION_INVOKER_SA_ID}
+    options:
+      responses:
+        '204':
+          description: CORS preflight
+      x-yc-apigateway-integration:
+        type: cloud_functions
+        function_id: ${FUNCTION_ID}
+        service_account_id: ${FUNCTION_INVOKER_SA_ID}
   /api/applications:
     get:
       responses:
@@ -68,6 +76,14 @@ paths:
                 properties:
                   error:
                     type: string
+      x-yc-apigateway-integration:
+        type: cloud_functions
+        function_id: ${FUNCTION_ID}
+        service_account_id: ${FUNCTION_INVOKER_SA_ID}
+    options:
+      responses:
+        '204':
+          description: CORS preflight
       x-yc-apigateway-integration:
         type: cloud_functions
         function_id: ${FUNCTION_ID}

--- a/infra/deploy-apigateway.sh
+++ b/infra/deploy-apigateway.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE_PATH="${1:-$SCRIPT_DIR/apigw-openapi.yaml}"
+OUTPUT_PATH="${2:-$SCRIPT_DIR/../apigw-openapi.resolved.yaml}"
+
+: "${FUNCTION_ID:?set FUNCTION_ID environment variable with target cloud function ID}"
+: "${YC_API_GATEWAY_NAME:?set YC_API_GATEWAY_NAME with API Gateway name}"
+: "${YC_FOLDER_ID:?set YC_FOLDER_ID with destination folder ID}"
+
+SERVICE_ACCOUNT_ID="${FUNCTION_INVOKER_SA_ID:-${YC_FUNCTION_INVOKER_SA_ID:-}}"
+
+cmd=(
+  node
+  "$SCRIPT_DIR/render-apigw.mjs"
+  "$TEMPLATE_PATH"
+  "$OUTPUT_PATH"
+  --function-id
+  "$FUNCTION_ID"
+)
+
+if [[ -n "$SERVICE_ACCOUNT_ID" ]]; then
+  cmd+=(--service-account-id "$SERVICE_ACCOUNT_ID")
+fi
+
+"${cmd[@]}"
+
+if yc serverless api-gateway get --name "$YC_API_GATEWAY_NAME" --folder-id "$YC_FOLDER_ID" >/dev/null 2>&1; then
+  echo "Updating existing API Gateway $YC_API_GATEWAY_NAME..."
+  yc serverless api-gateway update \
+    --name "$YC_API_GATEWAY_NAME" \
+    --folder-id "$YC_FOLDER_ID" \
+    --spec "$OUTPUT_PATH"
+else
+  echo "Creating API Gateway $YC_API_GATEWAY_NAME..."
+  yc serverless api-gateway create \
+    --name "$YC_API_GATEWAY_NAME" \
+    --folder-id "$YC_FOLDER_ID" \
+    --spec "$OUTPUT_PATH"
+fi
+
+yc serverless api-gateway get --name "$YC_API_GATEWAY_NAME" --folder-id "$YC_FOLDER_ID" --format json

--- a/infra/render-apigw.mjs
+++ b/infra/render-apigw.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function parseArgs(argv) {
+  const result = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const raw = argv[i];
+    if (!raw.startsWith('--')) continue;
+    const key = raw.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      result[key] = next;
+      i += 1;
+    } else {
+      result[key] = 'true';
+    }
+  }
+  return result;
+}
+
+const defaultTemplate = resolve(dirname(fileURLToPath(import.meta.url)), 'apigw-openapi.yaml');
+const defaultOutput = resolve(dirname(dirname(fileURLToPath(import.meta.url))), 'apigw-openapi.resolved.yaml');
+
+const [,, templateArg, outputArg, ...rest] = process.argv;
+const options = parseArgs(rest);
+
+const templatePath = resolve(templateArg || defaultTemplate);
+const outputPath = resolve(outputArg || defaultOutput);
+
+const functionId = options['function-id'] || process.env.FUNCTION_ID || process.env.YC_FUNCTION_ID;
+
+if (!functionId) {
+  console.error('render-apigw: --function-id (or FUNCTION_ID env) is required');
+  process.exitCode = 1;
+  process.exit(1);
+}
+
+const serviceAccountId = options['service-account-id']
+  || process.env.FUNCTION_INVOKER_SA_ID
+  || process.env.YC_FUNCTION_INVOKER_SA_ID
+  || '';
+
+let contents = readFileSync(templatePath, 'utf8');
+contents = contents.replaceAll('${FUNCTION_ID}', functionId);
+
+if (serviceAccountId) {
+  contents = contents.replaceAll('${FUNCTION_INVOKER_SA_ID}', serviceAccountId);
+} else {
+  const serviceAccountLine = /.*\$\{FUNCTION_INVOKER_SA_ID\}.*\n?/g;
+  contents = contents.replaceAll(serviceAccountLine, '');
+}
+
+writeFileSync(outputPath, contents, 'utf8');
+
+console.log(`Rendered API Gateway specification to ${outputPath}`);


### PR DESCRIPTION
## Summary
- add CORS preflight support to the API Gateway OpenAPI template
- add automation to render the template and deploy/update the gateway via `yc`
- document the manual deployment workflow in the infrastructure guide

## Testing
- `bash -n infra/deploy-apigateway.sh`
- `FUNCTION_ID=test node infra/render-apigw.mjs infra/apigw-openapi.yaml /tmp/apigw.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68d39a035da0832fa733a5ddc21d0957