### PR TITLE
Fix Cloud Function deployment source root

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ env:
   FUNCTION_RUNTIME: nodejs22
   FUNCTION_ENTRYPOINT: index.handler
   FUNCTION_MEMORY: 128Mb
-  FUNCTION_SOURCEROOT: src/functions/crop-image/
+  FUNCTION_SOURCEROOT: server/
   
 jobs:
   build:


### PR DESCRIPTION
## Summary
- point the Cloud Function workflow to use the server directory as the deployment source

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3a583bc40832f947f7d2e76924508