### PR TITLE
Deploy API gateway and static client in CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,9 @@ env:
   FUNCTION_ENTRYPOINT: index.handler
   FUNCTION_MEMORY: 128Mb
   FUNCTION_SOURCEROOT: server/
+  YC_API_GATEWAY_NAME: ${{ vars.YC_API_GATEWAY_NAME || 'form-networking-gw' }}
+  STATIC_BUCKET: ${{ vars.YC_STATIC_BUCKET || '' }}
+  FUNCTION_INVOKER_SA_ID: ${{ vars.YC_FUNCTION_INVOKER_SA_ID || '' }}
   
 jobs:
   build:
@@ -46,3 +49,61 @@ jobs:
             **/*.js
             **/*.html
             **/*.css
+      - name: Render API Gateway specification
+        env:
+          FUNCTION_ID: ${{ steps.sls-func.outputs.function-id }}
+          FUNCTION_INVOKER_SA_ID: ${{ env.FUNCTION_INVOKER_SA_ID }}
+        run: |
+          set -euo pipefail
+          extra=()
+          if [[ -n "${FUNCTION_INVOKER_SA_ID}" ]]; then
+            extra+=(--service-account-id "${FUNCTION_INVOKER_SA_ID}")
+          fi
+          node infra/render-apigw.mjs infra/apigw-openapi.yaml apigw-openapi.resolved.yaml --function-id "${FUNCTION_ID}" "${extra[@]}"
+      - name: Deploy API Gateway
+        id: deploy-gateway
+        uses: yc-actions/yc-api-gateway-deploy@v3.0.0
+        with:
+          yc-sa-id: ${{ env.SA_ID }}
+          folder-id: ${{ env.FOLDER_ID }}
+          gateway-name: ${{ env.YC_API_GATEWAY_NAME }}
+          spec-file: apigw-openapi.resolved.yaml
+      - name: Prepare static client assets
+        if: env.STATIC_BUCKET != ''
+        env:
+          API_DOMAIN: ${{ steps.deploy-gateway.outputs.domain }}
+        run: |
+          set -euo pipefail
+          workdir="dist/static"
+          rm -rf "$workdir"
+          mkdir -p "$workdir"
+          cp -R server/public/. "$workdir/"
+          api_base=""
+          if [[ -n "${API_DOMAIN}" ]]; then
+            api_base="https://${API_DOMAIN}"
+          fi
+          export WORKDIR="$workdir"
+          export API_BASE="$api_base"
+          node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const workdir = process.env.WORKDIR;
+const apiBase = (process.env.API_BASE || '').trim();
+if (!workdir) {
+  process.exit(0);
+}
+const indexPath = path.join(workdir, 'index.html');
+let html = fs.readFileSync(indexPath, 'utf8');
+html = html.replace(/%%API_BASE%%/g, apiBase);
+fs.writeFileSync(indexPath, html);
+NODE
+      - name: Upload static client to Object Storage
+        if: env.STATIC_BUCKET != ''
+        uses: yc-actions/yc-obj-storage-upload@v3.0.0
+        with:
+          yc-sa-id: ${{ env.SA_ID }}
+          bucket: ${{ env.STATIC_BUCKET }}
+          root: dist/static
+          cache-control: |
+            *.html: no-cache, no-store, must-revalidate
+            *.js, *.css: public, max-age=31536000, immutable

--- a/infra/DEPLOYMENT.md
+++ b/infra/DEPLOYMENT.md
@@ -26,12 +26,18 @@ Set the following repository variables to control the deployment targets:
 | `YC_FUNCTION_NAME` | `form-networking` | Cloud Function name. |
 | `YC_API_GATEWAY_NAME` | `form-networking-gw` | API Gateway name. |
 | `YC_FUNCTION_INVOKER_SA_ID` | _(optional)_ | Service account ID used by API Gateway to invoke the function. |
+| `YC_STATIC_BUCKET` | _(optional)_ | Object Storage bucket that serves the static web client. |
 | `DEMO_FLAG` | `true` | Value passed to the `DEMO` environment variable. |
 
 `YC_FUNCTION_INVOKER_SA_ID` should reference a service account that lives in the
 target folder and has the `serverless.functions.invoker` role on the function
 exposed through the API Gateway. When omitted, the workflow falls back to the
 service account ID embedded in `YC_SERVICE_ACCOUNT_KEY_B64`.
+
+When `YC_STATIC_BUCKET` is configured, the workflow renders
+`server/public/index.html` with the API Gateway domain and uploads all client
+assets from `server/public/` to that Object Storage bucket. Leave the variable
+empty to disable bucket uploads entirely.
 
 ## Manual gateway deployment
 


### PR DESCRIPTION
## Summary
- extend the CD workflow to render the API Gateway spec with the published function ID and deploy the gateway via `yc-actions/yc-api-gateway-deploy`
- add optional static asset packaging that rewrites the API base in `index.html` and uploads the client bundle to Object Storage when a bucket is configured
- document the new `YC_STATIC_BUCKET` repository variable in the deployment guide

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d3ab35b6fc832fa7164caccc85b1e7