### PR TITLE
Fix API Gateway deployment workflow

### DIFF
--- a/.github/workflows/cd-gateway.yml
+++ b/.github/workflows/cd-gateway.yml
@@ -15,7 +15,10 @@ env:
   FOLDER_ID: b1gr0igqr38nt8rm70li
   SA_ID: ajepvcf5o5fl77h8b2cf
   GATEWAY_NAME: form-networking-gw
-  OPENAPI_FILE: apigateway/openapi.yaml
+  FUNCTION_ID: ${{ vars.YC_GATEWAY_FUNCTION_ID || vars.YC_FUNCTION_ID || '' }}
+  FUNCTION_INVOKER_SA_ID: ${{ vars.YC_FUNCTION_INVOKER_SA_ID || '' }}
+  OPENAPI_TEMPLATE: infra/apigw-openapi.yaml
+  OPENAPI_FILE: apigw-openapi.resolved.yaml
 
 jobs:
   deploy-gateway:
@@ -36,11 +39,36 @@ jobs:
       #     token: ${{ secrets.CI_REPO_TOKEN }}
       #     fetch-depth: 1
 
-      - name: Sanity echo
+      - name: Verify configuration
         run: |
+          set -euo pipefail
           echo "Folder: $FOLDER_ID"
           echo "SA:     $SA_ID"
-          ls -la $(dirname "$OPENAPI_FILE") || true
+          echo "Template: $OPENAPI_TEMPLATE"
+          if [[ -z "$FUNCTION_ID" ]]; then
+            echo "FUNCTION_ID is not configured. Set repository variable YC_GATEWAY_FUNCTION_ID or YC_FUNCTION_ID with the Cloud Function ID." >&2
+            exit 1
+          fi
+          echo "Function ID: $FUNCTION_ID"
+          if [[ -n "$FUNCTION_INVOKER_SA_ID" ]]; then
+            echo "Invoker SA: $FUNCTION_INVOKER_SA_ID"
+          fi
+
+      - name: Render API Gateway specification
+        run: |
+          set -euo pipefail
+          cmd=(node infra/render-apigw.mjs "$OPENAPI_TEMPLATE" "$OPENAPI_FILE" --function-id "$FUNCTION_ID")
+          if [[ -n "$FUNCTION_INVOKER_SA_ID" ]]; then
+            cmd+=(--service-account-id "$FUNCTION_INVOKER_SA_ID")
+          fi
+          echo "Rendering API Gateway specification: ${cmd[*]}"
+          "${cmd[@]}"
+
+      - name: Sanity check
+        run: |
+          set -euo pipefail
+          echo "Resolved OpenAPI location: $OPENAPI_FILE"
+          ls -la "$(dirname "$OPENAPI_FILE")"
           test -f "$OPENAPI_FILE" || { echo "OpenAPI not found at $OPENAPI_FILE"; exit 1; }
 
       - name: Deploy API Gateway
@@ -49,7 +77,7 @@ jobs:
           yc-sa-id: ${{ env.SA_ID }}
           folder-id: ${{ env.FOLDER_ID }}
           gateway-name: ${{ env.GATEWAY_NAME }}
-          openapi-spec: ${{ env.OPENAPI_FILE }}
+          spec-file: ${{ env.OPENAPI_FILE }}
 
       - name: Done
         run: echo "API Gateway $GATEWAY_NAME deployed"


### PR DESCRIPTION
## Summary
- render the API Gateway spec from the existing template before deployment
- validate configuration variables, including the Cloud Function ID, before running the action
- call yc-api-gateway-deploy with the generated spec-file input

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3cdfab4c4832fafae2705f94f1f3b