### PR TITLE
Add message field to health response

### DIFF
--- a/apigateway/openapi.yaml
+++ b/apigateway/openapi.yaml
@@ -23,6 +23,9 @@ paths:
                 properties:
                   ok:
                     type: boolean
+                  message:
+                    type: string
+                    description: Human-readable health status.
         '400':
           description: Bad request
       x-yc-apigateway-integration:

--- a/apigw-openapi.resolved.yaml
+++ b/apigw-openapi.resolved.yaml
@@ -14,6 +14,8 @@ paths:
                 properties:
                   ok:
                     type: boolean
+                  message:
+                    type: string
       x-yc-apigateway-integration:
         type: cloud_functions
         function_id: example-function-id

--- a/infra/apigw-openapi.yaml
+++ b/infra/apigw-openapi.yaml
@@ -13,6 +13,9 @@ paths:
                 properties:
                   ok:
                     type: boolean
+                  message:
+                    type: string
+                    description: Human-readable health status.
       x-yc-apigateway-integration:
         type: cloud_functions
         function_id: ${FUNCTION_ID}

--- a/server/index.js
+++ b/server/index.js
@@ -155,7 +155,7 @@ export async function handler(event = {}) {
   }
 
   if (method === 'GET' && path === '/health') {
-    return jsonResponse(200, { ok: true });
+    return jsonResponse(200, { ok: true, message: 'healthy' });
   }
 
   if (path === '/api/applications') {


### PR DESCRIPTION
## Summary
- include a human-readable message in the health endpoint response
- document the new field in the API Gateway OpenAPI specifications

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3e09ac5e0832f93ea9c1ddee9fba9