### PR TITLE
Adjust OpenAPI spec for YC API Gateway

### DIFF
--- a/apigateway/openapi.yaml
+++ b/apigateway/openapi.yaml
@@ -5,9 +5,6 @@ info:
   license:
     name: MIT
     url: https://opensource.org/license/mit/
-servers:
-  - url: https://cloud.yandex.com
-security: []
 paths:
   /health:
     get:

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,5 @@
+extends:
+  - recommended
+rules:
+  no-empty-servers: off
+  security-defined: off


### PR DESCRIPTION
## Summary
- remove the unsupported global `servers` and `security` sections from the API Gateway OpenAPI definition
- add a Redocly CLI configuration that disables the lint checks requiring those sections so the workflow validation still passes

## Testing
- node infra/render-apigw.mjs apigateway/openapi.yaml apigateway/openapi.resolved.yaml --function-id dummy && npx --yes @redocly/cli@latest lint apigateway/openapi.resolved.yaml

------
https://chatgpt.com/codex/tasks/task_e_68d3e2730fb8832f9879be86fd0dafbb